### PR TITLE
Update getLevel2_full to v3

### DIFF
--- a/src/rest/Market/OrderBook.js
+++ b/src/rest/Market/OrderBook.js
@@ -68,7 +68,7 @@ exports.getLevel2_full = async function getLevel2_full(symbol) {
     }
   }
   */
-  return await Http().GET('/api/v2/market/orderbook/level2', { symbol });
+  return await Http().GET('/api/v3/market/orderbook/level2', { symbol });
 };
 
 


### PR DESCRIPTION
getLevel2_full references to v3 now and not the deprecated v2