### PR TITLE
Add option to Datafeed class to enable specific topics

### DIFF
--- a/src/lib/datafeed.js
+++ b/src/lib/datafeed.js
@@ -33,8 +33,10 @@ datafeed.subscribe(topic, (message) => {
  * Datafeed connect/subscribe manager
  */
 class Datafeed {
-  constructor(privateBullet = false) {
+  constructor(privateBullet = false, specific = false) {
     /** public */
+    // use specific topics or just topicPrefix's
+    this.specific = !!specific;
     // use private bullet link
     this.privateBullet = !!privateBullet;
     // real connected status
@@ -47,7 +49,7 @@ class Datafeed {
     this.topicState = [];
     // topic listener record
     this.topicListener = {
-      // topicPrefix => [...hooks],
+      // topic(Prefix) => [...hooks],
     };
     // subscribed id, auto inc
     this.incrementSubscribeId = 0;
@@ -218,7 +220,8 @@ class Datafeed {
 
     const hookId = this.incrementSubscribeId;
     const listener = { hook, id: hookId };
-    const prefix = getTopicPrefix(topic);
+    const prefix = this.specific?topic:getTopicPrefix(topic);
+    
     if (this.topicListener[prefix]) {
       this.topicListener[prefix].push(listener);
     } else {
@@ -247,7 +250,7 @@ class Datafeed {
    * @param {boolean} _private is close topic that push private data
    */
   unsubscribe(topic, hookId, _private = false) {
-    const prefix = getTopicPrefix(topic);
+    const prefix = this.specific?topic:getTopicPrefix(topic);
     if (this.topicListener[prefix]) {
       const deleted = this.topicListener[prefix].filter(item => item.id !== hookId);
       if (deleted.length === 0) {
@@ -265,7 +268,7 @@ class Datafeed {
   _distribute(message) {
     const { topic } = message;
     if (topic) {
-      const prefix = getTopicPrefix(topic);
+      const prefix = this.specific?topic:getTopicPrefix(topic);
       const listeners = this.topicListener[prefix];
       if (listeners) {
         _.each(listeners, ({ hook }) => {


### PR DESCRIPTION
Updates the constructor of the Datafeed class in src/lib/datafeed.js to take an additional Boolean parameter which defaults to false for backward compatibility.

When true, this enables "specific topics", where the topic listeners are added without taking the the prefix of their respective topic. This eliminates the usual check for each topic in the example below. I feel this is much more in line with the expected behaviour of Datafeed.subscribe(topic, hook) and definitely saves me a few lines when using the library.

It may be an idea in future to allow the creation of hooks which listen to multiple topics, however it would make more sense to have a separate set of functions for this.

```js
const kucoin = require('kucoin-node-sdk');

//Creating a new feed with the new specific parameter set true
let feed = new kucoin.websocket.Datafeed(false, true);

//typical datafeed setup
feed.connectSocket();
feed.onClose(()=>{console.log("datafeed closed");}

feed.subscribe('/market/match:BTC-USDT', msg=>{
  if(msg.topic === '/market/match:BTC-USDT') return; // no longer nessesary when specific=true
  
  //do stuff...
  
});

feed.subscribe('/market/match:ETH-USDT', msg=>{
  if(msg.topic === '/market/match:ETH-USDT') return; // no longer nessesary when specific=true
  
  //do stuff...
  
});
```

